### PR TITLE
feat: add readme clarifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,85 @@
 # trade-remedies-docker
 Master repo for building trade remedies system for local development.
 
-This repository provides a dockerised environment that can fetch, build and start all of the Trade Remedies applications and support systems. 
+This repository provides a dockerised environment that can fetch, build and start all of the
+Trade Remedies applications and support systems. 
 
-**This approach MUST be used for all local development.** If you have issues getting set up, please speak to a colleague on the Live Services Team.
+**This approach MUST be used for all local development.** If you have issues getting set up,
+please speak to a colleague on the Live Services Team.
 
 ## Makefile
+This project's `Makefile` provides an interface to manage this environment.
+To see a list of available commands run:
 
-The provided Makefile provides an interface to manage this environment. The following commands are available:
+    make help
 
-Run `make help` to see a list of available commands
+The following sections describes the commands required to get up and running.
 
 ## First run
+In a working directory run: 
 
-Run `make clone-repos`
+    make clone-repos
 
-This uses a SSH git clone by default. Run the following command if you want to use https:
+This uses a SSH git clone by default. Run the following command if you want
+to use https then run:
 
-Run `make clone-repos clonetype=https`
-
-Populate the project's local.env files with any missing values.
-
-Run `make first-use`
+    make clone-repos clonetype=https
 
 ### Required manual configuration
+In order to operate each service locally it's *very important* to populate each project's
+`trade-remedies-*/local.env` file with suitable values. See the inline comments in the files
+in the individual repositories and reach out to colleagues for API keys etc. 
 
-You *must* update values to your `local.env` files to operate the websites locally. See the inline comments in the individual repositories.
+### Build and initialise services
+You need to build and configure all the services for first use, simply run:
 
-Run `make collect-notify-templates`
+    make first-use
 
+#### Update notification template IDs
+Hopefully you've defined the `GOV_NOTIFY_API_KEY` in the `trade-remedies-api/local.env` file.
+If not, do it now, so that the API service can leverage the
+[GOV.UK Notify](https://www.notifications.service.gov.uk) notification service.
+
+To ensure your local system is configured to use the template IDs available in
+the notification service environment targeted by your `GOV_NOTIFY_API_KEY`
+you need to run the `notify_env` management command as follows:
+   
+    make collect-notify-templates
+
+This will update the local database to match the template IDs available.
+ 
 ## Compiling requirements
+We use [pip-compile](https://github.com/jazzband/pip-tools) to manage pip dependencies. If you add
+any new dependencies you should add them to the relevant project's `requirements.in`, then
+(in this project) run:
 
-We use pip-compile from https://github.com/jazzband/pip-tools to manage pip dependencies. This runs from the make file when generating requirements:
+    make all-requirements
 
-Run `make all-requirements`
-
-This needs to be run from the host machine as it does not run in a container.
+Make sure this is run from your host machine as it does not run in a container.
 
 ## BDD testing
+Behavioural testing is provided by [Behave Django](https://github.com/behave/behave-django)
+and can be triggered by running:
 
-Behavioural testing is provided by [Behave Django](https://github.com/behave/behave-django) and can be triggered by running:
+    make bdd
 
-`make bdd`
+This creates a test database (that is used by the `apitest` container), runs migrations and then
+initialises BDD tests.
 
-This make command creates a test database (that is used by the 'apitest' container), runs migrations and then initialises BDD tests.
+When running from within a BDD test, if the public or caseworker sites access the API, they access
+an endpoint on the `apitest` container (rather than the `api` container, as is usually the case).
 
-When running from within a BDD test, if the public or caseworker sites access the API, they access an endpoint on the 'apitest' container (rather than the 'api' container, as is usually the case).
+This means that BDD tests are completely siloed from local development infrastructure and can be run
+in parallel without affecting your local data.
 
-This means that BDD tests are completely siloed from local development infrastructure and can be run in parallel.
+The `apitest` container is configured to allow access to test object creation endpoints that are
+excluded from other configurations.
 
-The 'apitest' container is configured to allow access to test object creation endpoints that are excluded from other configurations.
+For this reason, the `api_test` app in the API project should never be added to non-test Django
+configurations.
 
-For this reason, the 'api_test' app in the API project should never be added to non test Django configurations.
-
-Nb. For BDD tests to execute, the containers need to be running. You can do this by running `make up`.
+> NB: For the BDD tests to execute, the all service containers need to be
+> running, i.e. execute the `make up` command.
 
 ## Sites
 
@@ -65,5 +91,6 @@ Nb. For BDD tests to execute, the containers need to be running. You can do this
 
 ## Known issues
 
-If, when first accessing the caseworker site, you receive a forbidden message, you need to clear your session and cookies.
+If, when first accessing the caseworker site, you receive a forbidden message, you need to clear your
+session and cookies.
 


### PR DESCRIPTION
# [TRLST-221](https://uktrade.atlassian.net/browse/TRLST-221)
In response to investigations to validate 3rd party invite template ids, added some clarifications to the README, in particular with regard to the purpose of the notify_env management command.

Basically I wanted to make the importance of  `make collect-notify-templates` stand out but got carried away making _all_ the `make` commands stand out. Also I’m not convinced the target name `collect-notify-templates` is ideal and would be happy to add a `Makefile` tweak to this PR (e.g. change target to `collect-notify-template-ids`).