### PR TITLE
feat: add celery service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # trade-remedies-docker
 Master repo for building trade remedies system for local development.
 
-This repository provides a dockerised environment that can fetch, build and start all of the
-Trade Remedies applications and support systems.
+This repository provides a dockerised environment that can fetch, build and
+start all the Trade Remedies applications and support systems. This includes
+the Trade Remedies services `api`, `caseworker` and `public` and supporting
+services for `postgres`, `redis`, `elasticsearch` and `celery`. To support BDD
+testing the services `apitest`, `selenium-hub` and `chrome` are also spun up.
 
 **This approach MUST be used for all local development.** If you have issues getting set up,
 please speak to a colleague on the Live Services Team.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,15 @@ services:
       service: elasticsearch
     networks:
       - proxynet
+  celery:
+    extends:
+      file: ../trade-remedies-api/docker-compose.yml
+      service: celery
+    networks:
+      - proxynet
+    depends_on:
+      - postgres
+      - redis
   api:
     extends:
       file: ../trade-remedies-api/docker-compose.yml


### PR DESCRIPTION
Add celery to the orchestration project. Accompanying PR on TR API will be raised to explain how local settings can be updated to utilise celery service rather than run tasks in-process.